### PR TITLE
Fixed case pattern matching for filetype highlighting.

### DIFF
--- a/zsh-syntax-highlighting-filetypes.zsh
+++ b/zsh-syntax-highlighting-filetypes.zsh
@@ -268,7 +268,7 @@ _zsh_main-highlight() {
           *) continue ;;
         esac
         case $arg in
-          $key) style=$ZSH_HIGHLIGHT_STYLES[$key] ;;
+          *.$key[3,-1]) style=$ZSH_HIGHLIGHT_STYLES[$key] ;;
         esac
         [ -n "$style" ] && break
       done


### PR DESCRIPTION
The `$key` as case matching [at line 271](https://github.com/trapd00r/zsh-syntax-highlighting-filetypes/blob/f40fbe42ecad3079e40b9be8439957ab442c9965/zsh-syntax-highlighting-filetypes.zsh#L271) is not working for me on zsh 5.0.5.

The variable looking like `*.ext` is taken literally by the interpreter and not matching any file (resulting in no filetype highlighting).

This can be solved replacing the case with `*.$key[3,-1]` (looks quite hacky I recognise).
