### PR TITLE
fix an error: some keys with now impact on text displayed a permission denied

### DIFF
--- a/zsh-syntax-highlighting-filetypes.zsh
+++ b/zsh-syntax-highlighting-filetypes.zsh
@@ -78,7 +78,7 @@ _zsh_highlight-zle-buffer-p() {
   local region_highlight_size="$1" highlight_predicate="$2"
   # If any highlightings are not taken into account, asume it is needed.
   # This holds for some up/down-history commands, for example.
-  ((region_highlight_size == 0)) || "$highlight_predicate"
+  ((region_highlight_size == 0)) || [[ -n "$highlight_predicate" ]] && "$highlight_predicate"
 }
 
 # Whether the command line buffer is modified or not.


### PR DESCRIPTION
Hello,
This PR add a new guard before triggering the `$highlight_predicate`:
When pressing **esc** (to go out of vim insert mode), the function was
trigger with an empty string leading to an annoying permission denied.
I have just added a check that `$highlight_predicate` is not empty.

Charles