### PR TITLE
Fix permission errors when used with zsh-users/zsh-syntax-highlighting

### DIFF
--- a/zsh-syntax-highlighting-filetypes.zsh
+++ b/zsh-syntax-highlighting-filetypes.zsh
@@ -61,9 +61,9 @@ _zsh_highlight-zle-buffer() {
       local cache_place=${zsh_highlight_caches[i]}
       local -a rh; rh=($region_highlight)
       {
-        "$func"
+        [[ -n "$func" ]] && whence "$func" &>/dev/null && "$func"
       } always  {
-        : ${(PA)cache_place::=${region_highlight:#(${(~j.|.)rh})}}
+        [[ -n "$cache_place" && "$cache_place" == [a-zA-Z_]* ]] && : ${(PA)cache_place::=${region_highlight:#(${(~j.|.)rh})}}
       }
     done
   } always {
@@ -78,7 +78,7 @@ _zsh_highlight-zle-buffer-p() {
   local region_highlight_size="$1" highlight_predicate="$2"
   # If any highlightings are not taken into account, asume it is needed.
   # This holds for some up/down-history commands, for example.
-  ((region_highlight_size == 0)) || "$highlight_predicate"
+  ((region_highlight_size == 0)) || { [[ -n "$highlight_predicate" ]] && "$highlight_predicate"; } 2>/dev/null
 }
 
 # Whether the command line buffer is modified or not.


### PR DESCRIPTION
## Problem
When using this plugin alongside `zsh-users/zsh-syntax-highlighting`, pressing backspace or enter on an empty command line produces errors like:
- `_zsh_highlight-zle-buffer-p:4: permission denied:`
- `_zsh_highlight-zle-buffer:25: permission denied:`
- `_zsh_highlight-zle-buffer:27: not an identifier:`

This happens because both plugins share internal arrays (`zsh_highlight_functions`, `zsh_highlight_predicates`, `zsh_highlight_caches`) and the newer zsh-users plugin registers entries that are incompatible with this plugin's expectations.

## Fix
- Validate that `$highlight_predicate` is non-empty before executing it
- Validate that `$func` exists as a callable function before invoking it
- Validate that `$cache_place` is a valid identifier before using it in parameter assignment

Builds on #12 with additional guards for the other affected code paths.

## Testing
Tested with both plugins loaded via antigen on zsh 5.9. Backspace and enter on empty command line no longer produce errors.